### PR TITLE
fix: response schema

### DIFF
--- a/src/event-horizon-timer-create-timer/index.mjs
+++ b/src/event-horizon-timer-create-timer/index.mjs
@@ -32,7 +32,15 @@ export async function handler(event) { // eslint-disable-line no-unused-vars -- 
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify(timerObject),
+      body: JSON.stringify({
+        timer: {
+          id: timerObject.id,
+          status: timerObject.status,
+          target_time: timerObject.target_time, // eslint-disable-line camelcase -- target_time
+          duration: timerObject.duration,
+          token: timerObject.token,
+        },
+      }),
     };
   } catch (error) {
     return {


### PR DESCRIPTION
* event-horizon-timer-create-timer のレスポンスが 885b62714d276fa33a3fcab412c4a12a42dfc54d で宣言した仕様に沿っていなかった問題を修正した
  * 仕様は timer というトップレベルのプロパティにオブジェクトを含めていた
  * 実装はトップレベルにオブジェクトをそのまま展開していた
* レスポンス中に、仕様で宣言していない client_ids というプロパティを含んでいたため、それを返さないように修正した。